### PR TITLE
Improve error handling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,13 +26,14 @@ export function testy(file) {
               evalExpected(path, result, offset),
             ]);
             if (actual.status === "rejected") {
-              // @ts-ignore
-              // If the actual status was rejected, we assume so was expected.
-              // Otherwise, it's a test failure
-              expect(actual.reason).to.eql(expected.reason);
-            } else {
-              // @ts-ignore
+              // If the example was rejected, and that's unexpected, then we should notify someone
+              if (expected.status !== "rejected") throw actual.reason;
+              // Else - Aha! We expected this! Make sure it's identical:
+              else expect(actual.reason).to.eql(expected.reason);
+            } else if (expected.status === "fulfilled") {
               expect(actual.value).to.eql(expected.value);
+            } else {
+              expect(actual.value).to.eql(expected.reason);
             }
           });
         }


### PR DESCRIPTION
- When the example code rejects, and the expected value did not (i.e., the tester did not expect an error) we throw the error and let someone else handle the reporting.
- In the case where an error was expected, but did not occur, expect the actual result to equal the expected error -- to improve the logic of the error in the expectations.
- Otherwise, expect the actual error / result to equal the expected.