### PR TITLE
Load each module once

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 import jsdoc from "jsdoc-api";
 import { expect } from "chai";
 import { evalExpected, getTests, runTest } from "./lib.js";
+import { pathToFileURL } from "url";
 
 /**
  * The main entry point. Call it with the path to the file to test, and run it
@@ -18,11 +19,17 @@ export function testy(file) {
 
   describe(file, () => {
     for (const { path, functionName, offset, examples } of tests) {
+      /** @type {any} */
+      let context;
+      before(async () => {
+        context = await import(pathToFileURL(path).href);
+      });
+
       describe(functionName, () => {
         for (const { test, example, expected: result } of examples) {
           it(example, async () => {
             const [actual, expected] = await Promise.allSettled([
-              runTest(path, test, offset),
+              runTest(path, test, offset, context),
               evalExpected(path, result, offset),
             ]);
             if (actual.status === "rejected") {

--- a/src/lib.js
+++ b/src/lib.js
@@ -118,6 +118,7 @@ export function getTests(doc) {
  * @param {string} path Path to the file under test
  * @param {string} test The test source
  * @param {Offset} offset The test source's line and column offset
+ * @param {any=} context The test context (the module under test)
  * @returns {Promise.<any>} The result of the evaluated test
  * @example runTest("src/lib.js", "1 - 2")
  * //=> -1
@@ -127,9 +128,10 @@ export function getTests(doc) {
 export async function runTest(
   path,
   test,
-  { line: lineOffset, column: columnOffset } = { line: 0, column: 0 }
+  { line: lineOffset, column: columnOffset } = { line: 0, column: 0 },
+  context
 ) {
-  const context = await import(pathToFileURL(resolve(path)).href);
+  context = context ?? (await import(pathToFileURL(resolve(path)).href));
   return vm.runInNewContext(
     test,
     { fs, ...context },


### PR DESCRIPTION
- Instead of importing a module each time a doctest runs, import the module once per file path and re-use it.
- If a module context is not supplied, the test runner will import it.