### PR TITLE
Improve test output, performance, structure

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,16 @@
 // @ts-ignore
 import jsdoc from "jsdoc-api";
 import { expect } from "chai";
-import { evalExpected, getTests, runTest } from "./lib.js";
-import { pathToFileURL } from "url";
+import { evalExpected, getTests, runTest, importPath } from "./lib.js";
 
 /**
  * The main entry point. Call it with the path to the file to test, and run it
  * using Mocha.
  *
+ * @typedef {{instance: any}} Options
+ *
  * @param {string} file
  * @example testy("src/lib.js")
- * //=> undefined
  */
 export function testy(file) {
   const doc = jsdoc.explainSync({ files: [file] });

--- a/src/index.js
+++ b/src/index.js
@@ -18,13 +18,13 @@ export function testy(file) {
   const tests = getTests(doc);
 
   describe(file, () => {
-    for (const { path, functionName, offset, examples } of tests) {
-      /** @type {any} */
-      let context;
-      before(async () => {
-        context = await import(pathToFileURL(path).href);
-      });
+    /** @type {any} */
+    let context;
+    before(async () => {
+      context = await importPath(file);
+    });
 
+    for (const { path, functionName, offset, examples } of tests) {
       describe(functionName, () => {
         for (const { test, example, expected: result } of examples) {
           it(example, async () => {

--- a/src/lib.js
+++ b/src/lib.js
@@ -14,7 +14,8 @@ import { pathToFileURL } from "node:url";
  *     lineno: number,
  *     columnno: number
  *   },
- *   name: string
+ *   name: string,
+ *   longname: string | undefined
  * }} Doclet
  *
  * @typedef {{
@@ -102,11 +103,12 @@ export function getTests(doc) {
       .map(
         ({
           meta: { path: directory, filename, lineno: line, columnno: column },
-          name: functionName,
+          name,
+          longname,
           examples,
         }) => ({
           path: posix.join(directory, filename),
-          functionName,
+          functionName: longname ?? name,
           offset: { line, column },
           examples,
         })

--- a/src/lib.js
+++ b/src/lib.js
@@ -133,7 +133,7 @@ export async function runTest(
   { line: lineOffset, column: columnOffset } = { line: 0, column: 0 },
   context
 ) {
-  context = context ?? (await import(pathToFileURL(resolve(path)).href));
+  context = context ?? (await importPath(path));
   return vm.runInNewContext(
     test,
     { fs, ...context },
@@ -177,4 +177,11 @@ export async function evalExpected(
     lineOffset,
     columnOffset,
   });
+}
+
+/**
+ * @param {string} path
+ */
+export async function importPath(path) {
+  return await import(pathToFileURL(resolve(path)).href);
 }

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,7 @@ import { testy } from "../src/index.js";
 
 // Let Testy test Testy - Quis probiet ipsos probates?
 describe("Testy", () => {
-  testy("src/index.js");
+  describe.skip("Skip entry point", () => testy("src/index.js"));
   testy("src/lib.js");
 });
 


### PR DESCRIPTION
- Skip testing src/index.js (mostly a gimmick, as it would run the src/lib.js tests)
- Use `longname` if available, which contains more information about e.g. methods
- Extract common method for importing modules, only import each file once