### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,4 +1,6 @@
 name: NPM
+permissions:
+  contents: read
 on:
   release:
     types: [created]


### PR DESCRIPTION
Potential fix for [https://github.com/linus/testy/security/code-scanning/5](https://github.com/linus/testy/security/code-scanning/5)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/npm.yml`. This block should be placed at the root level (alongside `name` and `on`) to apply to all jobs unless overridden. For NPM publishing by workflow, write access to repo contents is not required; the workflow merely needs to be able to check-out code (read), install dependencies, run tests, and publish to npm (which is handled by the npm token and does not require GitHub API permissions). Therefore, the minimum required permission is likely `contents: read`. Insert the following block after `name: NPM` and before `on:`:
```yaml
permissions:
  contents: read
```
No additional imports, methods, or variable definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
