### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/linus/testy/security/code-scanning/6](https://github.com/linus/testy/security/code-scanning/6)

To address the error, we should add a `permissions:` key that tightly restricts the job’s access. In the context provided, there is no evidence that any permission requiring write access is needed; the workflow only installs dependencies, checks out code, and runs tests, none of which require more than `contents: read`. The explicit `permissions:` block should therefore be either at the top workflow level (to apply to all jobs) or at the `jobs.tests` level (to apply only to that job). The most general and future-proof solution is to add it at the top, immediately after `name: CI` (line 1). Insert:

```yaml
permissions:
  contents: read
```

This ensures the minimal necessary access, regardless of organization or repository settings.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
